### PR TITLE
26 browse page images

### DIFF
--- a/utils/theme/globals.scss
+++ b/utils/theme/globals.scss
@@ -43,7 +43,12 @@ footer {
 }
 
 // override wcl v0.1.19
-.card > .cover {
+.card > img.cover,
+.card img.cover {
   object-fit: contain;
   padding: 20px;
+}
+
+.card .col-3 {
+  height: 170px;
 }


### PR DESCRIPTION
# Story
the images on the browse page were large too. especially the default ware after it was changed in #27. this change makes them look better. 

# Expected Behavior Before Changes

# Expected Behavior After Changes
- adjust the image sizes on the browse page
- give the services the same height for uniformity

# Screenshots / Video
<details>
<summary>before</summary>

<img width="1037" alt="image" src="https://github.com/scientist-softserv/phenovista-digital-storefront/assets/29032869/9131bdfc-ff44-4a95-9be4-7393c3bdb1e0">
</details>

after:
<img width="972" alt="image" src="https://github.com/scientist-softserv/phenovista-digital-storefront/assets/29032869/afd7873c-0712-444a-96ae-55553974cf13">


# Notes
