### PR TITLE
34 unable to create requests

### DIFF
--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -116,7 +116,7 @@ const NewRequest = ({ session }) => {
     if (requestForm.billingSameAsShipping === true) Object.assign(requestForm.billing, requestForm.shipping)
 
     const { data, error } = await createRequest({
-      dynamicFormData: { name: dynamicForm.name, formData, ...requestForm },
+      dynamicFormData: { ...dynamicForm, formData, ...requestForm },
       wareID,
       accessToken,
     })

--- a/utils/api/requests.js
+++ b/utils/api/requests.js
@@ -118,13 +118,17 @@ export const useFiles = (id, accessToken) => {
   }
 }
 
-
 export const useInitializeRequest = (id, accessToken) => {
   const { data, error } = useSWR(accessToken ? [`/wares/${id}/quote_groups/new.json`, accessToken] : null)
   let dynamicForm = { name: data?.name }
   let dynamicFormInfo = data?.dynamic_forms[0]
 
   if (dynamicFormInfo) {
+    dynamicForm = {
+      ...dynamicForm,
+      orderPriority: dynamicFormInfo.order_priority || 1,
+      parentDynamicFormId: dynamicFormInfo.parent_dynamic_form_id,
+    }
     const defaultSchema = dynamicFormInfo.schema
     const defaultOptions = dynamicFormInfo.options
     const schema = configureDynamicFormSchema(defaultSchema)
@@ -225,11 +229,14 @@ export const createRequest = async ({ dynamicFormData, wareID, accessToken }) =>
   })
 
   const pg_quote_group = {
-    ...formData,
     ...sharedRequestData,
     name: dynamicFormData.name,
     suppliers_identified: 'Yes',
     description: requestDescription,
+    data_str: JSON.stringify(formData),
+    dynamic_forms_to_embed: [
+      { id: dynamicFormData.parentDynamicFormId, order_priority: dynamicFormData.orderPriority }
+    ],
     no_proposed_deadline: dynamicFormData.proposedDeadline ? false : true,
     timeline: requestTimeline,
   }


### PR DESCRIPTION
# Story
when a description is not provided, the validations fail. we are now passing the `data_str` and `dynamic_forms_to_embed` properties when creating a new request as their presence allow the validations to pass, even in the absence of a description.

ref:
- https://github.com/assaydepot/rx/blob/main/app/models/pg/quote_group.rb#L778-L781
- https://assaydepot.slack.com/archives/CF6490Y80/p1705098558758609?thread_ts=1704996805.983419&cid=CF6490Y80


# Expected Behavior After Changes
- able to create requests again

# Screenshots / Video

![image](https://github.com/scientist-softserv/phenovista-digital-storefront/assets/29032869/8f0397ab-414b-4280-9106-c5f0b3344fd4)
