### PR TITLE
36 update charts for gtm

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,3 @@ NEXT_PUBLIC_PROVIDER_ID=12527
 NEXT_PUBLIC_SCIENTIST_API_VERSION=v2
 NEXT_PUBLIC_WEBHOOK_URL=http://ss-mailer/webstore
 NEXT_PUBLIC_APP_BASE_URL=https://www.phenovista.vercel.app
-
-# optional/conditional variables
-GOOGLE_TAG_MANAGER_ID=GTM-PQGCP24G

--- a/charts/webstore/templates/deployment.yaml
+++ b/charts/webstore/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
               value: "{{ .Values.clientSecret }}"
             - name: CLIENT_ID
               value: "{{ .Values.clientId }}"
+            - name: GOOGLE_TAG_MANAGER_ID
+              value: "{{ .Values.googleTagManagerId }}"
             - name: NEXTAUTH_SECRET
               value: "{{ .Values.nextAuthSecret }}"
             - name: NEXTAUTH_URL

--- a/charts/webstore/values.yaml
+++ b/charts/webstore/values.yaml
@@ -14,6 +14,7 @@ appBaseUrl: ''
 clientId: ''
 clientSecret: ''
 fullnameOverride: ''
+googleTagManagerId: ''
 imagePullSecrets: []
 nameOverride: ''
 nextAuthSecret: ''

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -1,6 +1,7 @@
 appBaseUrl: 'https://phenovista.softserv.cloud'
 clientId: $CLIENT_ID
 clientSecret: $CLIENT_SECRET
+googleTagManagerId: 'GTM-PQGCP24G'
 nextAuthSecret: $NEXTAUTH_SECRET
 nextAuthUrl: 'https://phenovista.softserv.cloud/api/auth'
 nextPublicToken: $NEXT_PUBLIC_TOKEN

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -1,6 +1,7 @@
 appBaseUrl: 'https://phenovista-staging.softserv.cloud'
 clientId: $CLIENT_ID
 clientSecret: $CLIENT_SECRET
+googleTagManagerId: ''
 nextAuthSecret: $NEXTAUTH_SECRET
 nextAuthUrl: 'https://phenovista-staging.softserv.cloud/api/auth'
 nextPublicToken: $NEXT_PUBLIC_TOKEN

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -21,7 +21,6 @@ import {
   headerAndFooterLinkColors,
 } from '../utils'
 import '../utils/theme/globals.scss'
-const gtmId = process.env.NODE_ENV === 'production' ? process.env.GOOGLE_TAG_MANAGER_ID : ''
 
 const WebStore = ({ Component }) => {
   /**
@@ -42,7 +41,7 @@ const WebStore = ({ Component }) => {
         enableCookies={enableCookies}
         getCookieConsent={getCookieConsent()}
       /> */}
-      <GoogleTagManager gtmId={gtmId} />
+      <GoogleTagManager gtmId={process.env.GOOGLE_TAG_MANAGER_ID} />
       <Header
         auth={{
           signIn: () => signIn(process.env.NEXT_PUBLIC_PROVIDER_NAME),


### PR DESCRIPTION
# Story
update charts for gtm to work in deployment

since `GOOGLE_TAG_MANAGER_ID` is being referenced through an environment variable, it needed to be added as a deployment variable as well. we only need this value accessible in production, so I was able to remove it from the local env. the value should return as "undefined" and "" in the local and staging environments, respectively.

related: https://github.com/scientist-softserv/phenovista-digital-storefront/pull/37

# Expected Behavior After Changes
- google tag manager is active in the production environment only

# Notes
I deployed this branch to main, but the gtm id still wasn't picked up. I'm thinking that the deploy updates need to actually be in `main` to be picked up.