### PR TITLE
36 gtm for the last time

### DIFF
--- a/charts/webstore/templates/deployment.yaml
+++ b/charts/webstore/templates/deployment.yaml
@@ -38,14 +38,14 @@ spec:
               value: "{{ .Values.clientSecret }}"
             - name: CLIENT_ID
               value: "{{ .Values.clientId }}"
-            - name: GOOGLE_TAG_MANAGER_ID
-              value: "{{ .Values.googleTagManagerId }}"
             - name: NEXTAUTH_SECRET
               value: "{{ .Values.nextAuthSecret }}"
             - name: NEXTAUTH_URL
               value: "{{ .Values.nextAuthUrl }}"
             - name: NEXT_PUBLIC_APP_BASE_URL
               value: "{{ .Values.appBaseUrl }}"
+            - name: NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID
+              value: "{{ .Values.googleTagManagerId }}"
             - name: NEXT_PUBLIC_PROVIDER_ID
               value: "{{ .Values.providerId }}"
             - name: NEXT_PUBLIC_PROVIDER_NAME

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -41,7 +41,7 @@ const WebStore = ({ Component }) => {
         enableCookies={enableCookies}
         getCookieConsent={getCookieConsent()}
       /> */}
-      <GoogleTagManager gtmId={process.env.GOOGLE_TAG_MANAGER_ID} />
+      <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID} />
       <Header
         auth={{
           signIn: () => signIn(process.env.NEXT_PUBLIC_PROVIDER_NAME),


### PR DESCRIPTION
# Story
I thought that the reason the GTM ID wasn't showing on production after deploying [my branch](https://github.com/scientist-softserv/phenovista-digital-storefront/pull/38) to production was because the deploy changes needed to be in main to take effect. however, after merging the above to main and deploying again, the GTM ID still doesn't show up.

I now believe the issue is related to the `NEXT_PUBLIC` prefix. Added it to the GTM ID so that the client should be able to pick up the variable.

# Expected Behavior After Changes
- the GTM ID is finally visible on prod

# Screenshots / Video
the id is visible in the blue section!

![image](https://github.com/scientist-softserv/phenovista-digital-storefront/assets/29032869/8578aa33-6c17-4437-a3ad-cc0d7c16c63a)