### PR TITLE
upgrade webstore component library

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@rjsf/core": "^5.0.0-beta.17",
     "@rjsf/utils": "^5.0.0-beta.17",
     "@rjsf/validator-ajv8": "^5.0.1",
-    "@scientist-softserv/webstore-component-library": "^0.1.19",
+    "@scientist-softserv/webstore-component-library": "^0.1.20",
     "@sentry/nextjs": "^7.42.0",
     "axios": "^1.1.3",
     "bootstrap": "^5.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1073,10 +1073,10 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.6.0.tgz#1898e7a7b943680d757417a47fb10f5fcc230b39"
   integrity sha512-2/U3GXA6YiPYQDLGwtGlnNgKYBSwCFIHf8Y9LUY5VATHdtbLlU0Y1R3QoBnT0aB4qv/BEiVVsj7LJXoQCgJ2vA==
 
-"@scientist-softserv/webstore-component-library@^0.1.19":
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/@scientist-softserv/webstore-component-library/-/webstore-component-library-0.1.19.tgz#3cec0f9a35a750739153bdf40f62101903965319"
-  integrity sha512-ZCwrUXIw9D+opFWrRC0yChayoqGbvDKos+6ZZ8utQovwJbcdfQvLc8T4bItteN6ssrAHJn2tIrJDFfQxD3f2xg==
+"@scientist-softserv/webstore-component-library@^0.1.20":
+  version "0.1.20"
+  resolved "https://registry.yarnpkg.com/@scientist-softserv/webstore-component-library/-/webstore-component-library-0.1.20.tgz#55962074fe70fdab60ebcbe9f2cb27a3a9b797dd"
+  integrity sha512-BpyESRx6F9OVogcZZsFkOpSDyG6BFkik/wG5ZDsGHwNjbkXSBgsV3BuoWyTbmXQHiOwJeEtgQwBGHYvqkiOC4Q==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.2.1"
     "@fortawesome/free-regular-svg-icons" "^6.2.1"


### PR DESCRIPTION
# Story
upgrade `@scientist-softserv/webstore-component-library` to 0.1.20

# notes
although the wcl was updated, the expected changes are not working locally, or at the deployed vercel site. holding off on merging until we can get the changes to work. ref: [wcl 0.1.20 release notes](https://github.com/scientist-softserv/webstore-component-library/releases/tag/0.1.20).