### PR TITLE
HOTFIX: 51 dynamic form radios

### DIFF
--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -324,9 +324,9 @@ export const configureDynamicFormUiSchema = (schema, defaultOptions) => {
         case 'checkbox':
           fieldOptions['ui:widget'] = 'checkboxes'
           break
-        case 'radio':
-          fieldOptions['ui:widget'] = 'radio'
-          break
+        // case 'radio':
+        //   fieldOptions['ui:widget'] = 'radio'
+        //   break
         default:
           fieldOptions['ui:inputType'] = fields[key].type
         }


### PR DESCRIPTION
# Story
revert to select drop downs instead of radios

this is a hotfix so that we're able to view the page on production at least.

will be looking into why the radio isn't working for Ready-2-Go AAV Gene Delivery Assay Service. the error states "No widget 'radio' for type 'array'", but there isn't a { type: array } in options.fields for this service.

- ref: https://github.com/scientist-softserv/phenovista-digital-storefront/issues/51

# Screenshots / Video
![image](https://github.com/scientist-softserv/phenovista-digital-storefront/assets/29032869/b9b0f9e6-9b30-4033-a171-2987c3580bd4)
