### PR TITLE
51-fix-radio-buttons

### DIFF
--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -324,9 +324,9 @@ export const configureDynamicFormUiSchema = (schema, defaultOptions) => {
         case 'checkbox':
           fieldOptions['ui:widget'] = 'checkboxes'
           break
-        // case 'radio':
-        //   fieldOptions['ui:widget'] = 'radio'
-        //   break
+        case 'radio':
+          fieldOptions['ui:widget'] = 'radio'
+          break
         default:
           fieldOptions['ui:inputType'] = fields[key].type
         }


### PR DESCRIPTION
# Story
account for radio widgets again

the issue with the Ready-2-Go AAV Gene Delivery Assay Service not rendering was actually due to the dynamic form, not the code. the value of `properties.markers.type` was updated to "string" instead of "array", ridding us of the "No widget 'radio' for type 'array'" error.

ref:
- https://github.com/scientist-softserv/phenovista-digital-storefront/issues/51

# Screenshots / Video
<img width="1192" alt="image" src="https://github.com/scientist-softserv/phenovista-digital-storefront/assets/29032869/9555864a-93bb-4bd7-983e-b973a30d4043">