### PR TITLE
56-sentry-type-error

### DIFF
--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -181,7 +181,7 @@ const NewRequest = ({ session }) => {
         {dynamicForm.schema ? (
           <>
             <TextBox
-              text={ware.snippet}
+              text={ware?.snippet}
               size='large'
               style={{ fontWeight: '550' }}
             />


### PR DESCRIPTION
# Story
do not throw an error while `ware` is undefined

the sentry error reads: "TypeError: Cannot read properties of undefined (reading 'snippet')". `snippet` is only referenced 2 places in the code. the new request page, and in `configureServices`. after looking at both options, the most likely place this error came from is the new request page. the mention in `configureServices` only happens if the ware/service is present, and therefore not undefined as the error mentions.

sentry notes that the error occurred while trying to get the service with id 6055. I do not have any issue with that ware locally right now. however, I'm adding a conditional to confirm that the ware is present before trying to access the `snippet` property.

- ref: #56