### PR TITLE
36-gtm-refactor

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -21,6 +21,7 @@ import {
   headerAndFooterLinkColors,
 } from '../utils'
 import '../utils/theme/globals.scss'
+const gtmId = process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID
 
 const WebStore = ({ Component }) => {
   /**
@@ -41,7 +42,7 @@ const WebStore = ({ Component }) => {
         enableCookies={enableCookies}
         getCookieConsent={getCookieConsent()}
       /> */}
-      <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID} />
+      {gtmId && <GoogleTagManager gtmId={gtmId} />}
       <Header
         auth={{
           signIn: () => signIn(process.env.NEXT_PUBLIC_PROVIDER_NAME),


### PR DESCRIPTION
# Story
only load google tag manager if an id is present.

the prior implementation wasn't causing user problems, but it was throwing console errors when the id was undefined. which is in all cases except for production.

- ref: #36

# Expected Behavior Before Changes
<img width="622" alt="image" src="https://github.com/scientist-softserv/phenovista-digital-storefront/assets/29032869/49573502-ad62-48dc-a32f-294c621a7e3c">

# Expected Behavior After Changes
the above error isn't in the console anymore.
