### PR TITLE
rename-webhook

### DIFF
--- a/utils/api/webhooks.js
+++ b/utils/api/webhooks.js
@@ -11,7 +11,7 @@ export const getWebhookConfig = async (accessToken) => {
 export const createWebhookConfig = (accessToken) => {
   /* eslint-disable camelcase */
   const webhook_config = {
-    'name': 'Webstore',
+    'name': `${process.env.NEXT_PUBLIC_PROVIDER_NAME} DS`,
     'url': `${process.env.NEXT_PUBLIC_WEBHOOK_URL}`,
     'active': true,
     'params': {


### PR DESCRIPTION
# Story
application specific webhook names

webhooks are tied to a specific client application on the scientist.com marketplace. currently, they're all titled "webstore", which means a user can have multiple webhooks that are named the same, but refer to different applications. this change makes each webhook name unique by referencing the name of the client application.

I'll also be manually updating existing webstore related webhook names through the scientist production console after this pr is merged.

- related: https://github.com/assaydepot/rx/issues/25317