### PR TITLE
65 update auth url

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -3,6 +3,7 @@ CLIENT_SECRET= # Retrieved from the marketplace application show page under Deve
 NEXTAUTH_SECRET= # Create this by running `openssl rand -base64 32` in your terminal. (https://next-auth.js.org/configuration/options#nextauth_secret)
 NEXTAUTH_URL= # https://next-auth.js.org/configuration/options#nextauth_url
 NEXT_PUBLIC_TOKEN= # Ref: "Provider Credentials" in the README
+NEXT_PUBLIC_CLIENT_DOMAIN= # Ref: "Creating The Marketplace App" in the README
 
 # uncomment the “SENTRY” prefixed variables below if you are using sentry and need to catch errors in local dev
 # SENTRY_AUTH_TOKEN= ref: https://github.com/getsentry/sentry-webpack-plugin#options (authToken)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ _The terms "client" and "provider" are fairly interchangeable in this applicatio
 | NEXTAUTH_SECRET | Yes | .env.development | Used to encrypt the NextAuth.js JWT |
 | NEXTAUTH_URL | Yes | .env.development | The authentication route used for NextAuth.js |
 | NEXT_PUBLIC_APP_BASE_URL | Yes | .env | The URL to the deployed webstore instance |
+| NEXT_PUBLIC_CLIENT_DOMAIN | No | .env.development | The domain attached to the Client App. Ref: Creating The Marketplace App |
 | NEXT_PUBLIC_PROVIDER_ID | Yes | .env | The identifier of the client's marketplace in the database |
 | NEXT_PUBLIC_PROVIDER_NAME | Yes | .env | The subdomain of the client's marketplace |
 | NEXT_PUBLIC_SCIENTIST_API_VERSION | Yes | .env | The version of the API we should be talking to |
@@ -60,7 +61,7 @@ _The terms "client" and "provider" are fairly interchangeable in this applicatio
 | SENTRY_URL | No | .env.development | The base URL of the Sentry instance |
 
 ### Creating The Marketplace App
-Ensure that a marketplace, e.g. client-name.scientist.com, has been created by the Scientist.com Professional Services team. Once that exists, an application needs to be created on that marketplace by a developer with the proper permissions. This is how some of the environment variables are created. You'll know if you have the proper developer permissions if once logged in on the client marketplace, you can hover over your avatar and see "Applications" underneath the "Developer" settings. _If you don't have the permissions, you need to request them, or ask someone with the permissions to complete the steps below._
+Ensure that a marketplace, e.g. client-name.<NEXT_PUBLIC_CLIENT_DOMAIN>.com, has been created by the Scientist.com Professional Services team. Once that exists, an application needs to be created on that marketplace by a developer with the proper permissions. This is how some of the environment variables are created. You'll know if you have the proper developer permissions if once logged in on the client marketplace, you can hover over your avatar and see "Applications" underneath the "Developer" settings. _If you don't have the permissions, you need to request them, or ask someone with the permissions to complete the steps below._
 - Once you've clicked the "Applications" link mentioned above, press "New Application"
   - Only the application name is required for the moment. Name it the same as the provider name.
 - Save, and you should be redirected to the "Developer Details" page

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -2,6 +2,7 @@ import NextAuth from 'next-auth'
 import axios from 'axios'
 // TODO(alishaevn): use the api value from https://github.com/assaydepot/rx/issues/21497 in the next phase
 import { EXPIRATION_DURATION, getWebhookConfig, createWebhookConfig } from '../../../utils'
+const authorizationDomain = process.env.NEXT_PUBLIC_CLIENT_DOMAIN || 'scientist.com'
 
 // For more information on each option (and a full list of options) go to: https://next-auth.js.org/configuration/options
 const authOptions = {
@@ -14,8 +15,8 @@ const authOptions = {
       checks: ['pkce', 'state'],
       clientId: process.env.CLIENT_ID,
       clientSecret: process.env.CLIENT_SECRET,
-      authorization: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/oauth/authorize`,
-      token: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/oauth/token`,
+      authorization: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.${authorizationDomain}/oauth/authorize`,
+      token: `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.${authorizationDomain}/oauth/token`,
       userinfo: {
         // The result of this function will be the input to the `profile` callback.
         async request(context) {
@@ -68,7 +69,7 @@ const authOptions = {
  */
 const refreshAccessToken = async (token) => {
   try {
-    const url = `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.scientist.com/oauth/token`
+    const url = `https://${process.env.NEXT_PUBLIC_PROVIDER_NAME}.${authorizationDomain}/oauth/token`
     const encodedString = Buffer.from(`${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`).toString('base64')
     const params = new URLSearchParams({
       /* eslint-disable camelcase */


### PR DESCRIPTION
# Story
use "assayexpress.com" as the auth domain
created as a variable to maintain flexibility once this code is merged back to the webstore template.

- ref: https://github.com/scientist-softserv/phenovista-digital-storefront/issues/65

# Expected Behavior After Changes
logging in redirects the user to phenovista.assayexpress.com instead of phenovista.scientist.com

# Instructions
1. sign out of the app if you're already signed in
2. press "sign in" in the header
3. observe that you've been redirected to phenovista.assayexpress.com
4. log in using sso
5. authorize the app if necessary
6. be redirected to the digital storefront
