### PR TITLE
69-error-on-two-request-pages

### DIFF
--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -262,7 +262,7 @@ export const configureDynamicFormSchema = (defaultSchema) => {
 
   Object.entries(defaultSchema.properties).forEach(prop => {
     const [key, value] = prop
-    let adjustedProperty
+    let adjustedProperty = prop
 
     if (!removedProperties.includes(key)) {
       if (value.required) {


### PR DESCRIPTION
# Story
make sure "adjustedProperty" always exists

setting "adjustedProperty" to be the initial property makes sure that it exists even when a property doesn't have "dependency" or "required" fields

- ref: scientist-softserv/phenovista-digital-storefront#69

# Expected Behavior After Changes
- the "Cell Painting" request form loads
- the "Custom Assay Services" request form loads
- clicking the "Initiate a new request" button from "/requests" loads a request form

# Screenshots / Video
![image](https://github.com/scientist-softserv/phenovista-digital-storefront/assets/29032869/8ba3bcff-f68f-4159-b3ed-77a73c6be2ab)


# Notes
