### PR TITLE
Accurately make sure "adjustedProperty" exists (#69)

### DIFF
--- a/utils/api/configurations.js
+++ b/utils/api/configurations.js
@@ -262,7 +262,7 @@ export const configureDynamicFormSchema = (defaultSchema) => {
 
   Object.entries(defaultSchema.properties).forEach(prop => {
     const [key, value] = prop
-    let adjustedProperty = prop
+    let adjustedProperty = value
 
     if (!removedProperties.includes(key)) {
       if (value.required) {


### PR DESCRIPTION
# Story
`prop` is an array holding the key and value. we actually want to set `adjustedProperty` to be the value of the prop so that we can deconstruct it later.

- #69
- related: https://github.com/scientist-softserv/phenovista-digital-storefront/pull/78

![image](https://github.com/scientist-softserv/phenovista-digital-storefront/assets/29032869/a65a2489-4b40-44fc-95ea-213c4825436b)