### PR TITLE
Remove html encoded spaces from service snippets (#76)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cookies-next": "^4.0.0",
     "eslint": "^8.54.0",
     "eslint-config-next": "^14.0.3",
+    "he": "^1.2.0",
     "next": "12.3.1",
     "next-auth": "^4.20.1",
     "react": "18.2.0",

--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { default as BsForm } from 'react-bootstrap/Form'
 import Form from '@rjsf/core'
 import validator from '@rjsf/validator-ajv8'
+import he from 'he'
 import { useRouter } from 'next/router'
 import { signIn } from 'next-auth/react'
 import {
@@ -19,7 +20,6 @@ import {
   buttonBg,
   configureErrors,
   createRequest,
-  removeHtmlSpaces,
   requestFormHeaderBg,
   sendRequestToVendor,
   useInitializeRequest,
@@ -182,11 +182,13 @@ const NewRequest = ({ session }) => {
         <Title title={dynamicForm.name || ''} addClass='my-4' />
         {dynamicForm.schema ? (
           <>
-            <TextBox
-              text={removeHtmlSpaces(ware?.snippet)}
-              size='large'
-              style={{ fontWeight: '550' }}
-            />
+            {he.decode(ware?.snippet).trim() &&
+              <TextBox
+                text={ware.snippet}
+                size='large'
+                style={{ fontWeight: '550' }}
+              />
+            }
             <Form
               formData={formData}
               onChange={e => setFormData(e.formData)}

--- a/pages/requests/new/[ware].js
+++ b/pages/requests/new/[ware].js
@@ -19,6 +19,7 @@ import {
   buttonBg,
   configureErrors,
   createRequest,
+  removeHtmlSpaces,
   requestFormHeaderBg,
   sendRequestToVendor,
   useInitializeRequest,
@@ -182,7 +183,7 @@ const NewRequest = ({ session }) => {
         {dynamicForm.schema ? (
           <>
             <TextBox
-              text={ware?.snippet}
+              text={removeHtmlSpaces(ware?.snippet)}
               size='large'
               style={{ fontWeight: '550' }}
             />

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -89,8 +89,3 @@ export const truncateDescription = (desc = '', maxLength, isOpen) => {
   const ellipsis = isOpen ? '' : '...'
   return { truncated: desc.slice(0, lastSpaceIndex) + ellipsis, cutOffIndex: lastSpaceIndex }
 }
-
-export const removeHtmlSpaces = (text) => {
-  const regex = /&[a-z]+;/g
-  return text?.replace(regex, '')
-}

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -89,3 +89,8 @@ export const truncateDescription = (desc = '', maxLength, isOpen) => {
   const ellipsis = isOpen ? '' : '...'
   return { truncated: desc.slice(0, lastSpaceIndex) + ellipsis, cutOffIndex: lastSpaceIndex }
 }
+
+export const removeHtmlSpaces = (text) => {
+  const regex = /&[a-z]+;/g
+  return text?.replace(regex, '')
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4546,6 +4546,11 @@ hastscript@^8.0.0:
     property-information "^6.0.0"
     space-separated-tokens "^2.0.0"
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"


### PR DESCRIPTION
# Story
`&nbsp;` translates to an empty space in html (and markup apparently). it is not working the same when passed to the TextBox component though. the text itself shows. this commit will filter out that text, while leaving the remaining words, if any.

- scientist-softserv/phenovista-digital-storefront#76

# Expected Behavior Before Changes
![image](https://github.com/scientist-softserv/phenovista-digital-storefront/assets/29032869/7424b673-bf92-4e0f-bcca-2133765495d4)

# Expected Behavior After Changes
![image](https://github.com/scientist-softserv/phenovista-digital-storefront/assets/29032869/140bf081-c84f-4034-b765-26e9b18b57b7)

# Screenshots
![image](https://github.com/scientist-softserv/phenovista-digital-storefront/assets/29032869/034650f9-bda6-4675-a3f9-a3dec7a136ba)
