### PR TITLE
stop cypress from running in ci

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -22,16 +22,16 @@ jobs:
     with:
       platforms: 'linux/amd64'
       webTarget: web
-  cypress:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Cypress e2e
-        uses: cypress-io/github-action@v6
-        with:
-          start: yarn start
-          wait-on: 'http://localhost:3000'
+  # cypress:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #     - name: Cypress e2e
+  #       uses: cypress-io/github-action@v6
+  #       with:
+  #         start: yarn start
+  #         wait-on: 'http://localhost:3000'
   eslint:
     needs: build
     uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.13


### PR DESCRIPTION
cypress is currently broken in ci. it order to have a green pipeline, we are stopping it from running until it is fixed in the main webstore repo.
at that point, the fixes should be brought back here, and the pipeline reinstated

- https://github.com/scientist-softserv/webstore/issues/378

# Expected Behavior After Changes
a completely green pipeline.